### PR TITLE
Use extra headers option when request swagger.json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [str(i.req) for i in parse_requirements('requirements_dev.tx
 
 setup(
     name='swagger_tester',
-    version='0.2.7',
+    version='0.2.8',
     description="Automatically test your swagger API",
     long_description=readme + '\n\n' + history,
     author="Cyprien Guillemot",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [str(i.req) for i in parse_requirements('requirements_dev.tx
 
 setup(
     name='swagger_tester',
-    version='0.2.8',
+    version='0.2.9',
     description="Automatically test your swagger API",
     long_description=readme + '\n\n' + history,
     author="Cyprien Guillemot",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [str(i.req) for i in parse_requirements('requirements_dev.tx
 
 setup(
     name='swagger_tester',
-    version='0.2.9',
+    version='0.2.10',
     description="Automatically test your swagger API",
     long_description=readme + '\n\n' + history,
     author="Cyprien Guillemot",

--- a/swagger_tester/swagger_tester.py
+++ b/swagger_tester/swagger_tester.py
@@ -310,7 +310,7 @@ def swagger_test_yield(swagger_yaml_path=None, app_url=None, authorize_error=Non
                     continue
                 response = get_method_from_action(app_client, action)(url, headers=headers, data=body)
             else:
-                if app_url.endswith(swagger_parser.base_path):
+                if swagger_parser.base_path and app_url.endswith(swagger_parser.base_path):
                     base_url = app_url[:-len(swagger_parser.base_path)]
                 else:
                     base_url = app_url

--- a/swagger_tester/swagger_tester.py
+++ b/swagger_tester/swagger_tester.py
@@ -269,7 +269,7 @@ def swagger_test_yield(swagger_yaml_path=None, app_url=None, authorize_error=Non
         swagger_parser = SwaggerParser(swagger_yaml_path, use_example=use_example)
     elif app_url is not None:
         app_client = requests
-        remote_swagger_def = requests.get(u'{0}/swagger.json'.format(app_url)).json()
+        remote_swagger_def = requests.get(u'{0}/swagger.json'.format(app_url), headers=extra_headers).json()
         swagger_parser = SwaggerParser(swagger_dict=remote_swagger_def, use_example=use_example)
     else:
         raise ValueError('You must either specify a swagger.yaml path or an app url')


### PR DESCRIPTION
Usually if you have an API protected by and api key you have it on all endpoints. By sending the extra header on the request to the /swagger.json we make this possible or more convenient.